### PR TITLE
Docker file fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm as base
 
+RUN apt-get update \
+    && apt-get install -y \
+        curl \
+        git \
+        unzip \
+        vim \
+        wget \
+        gcc \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean 
+
 RUN pip install --no-cache "poetry>1.7,<1.8" 
 RUN poetry config virtualenvs.create false
 
@@ -12,16 +23,6 @@ RUN poetry install --no-dev --no-interaction --no-ansi --no-root -vv \
 
 # Dev Container
 FROM base as devcontainer
-
-RUN apt-get update \
-    && apt-get install -y \
-        curl \
-        git \
-        unzip \
-        vim \
-        wget \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean 
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm as base
 
-# Set the timezone so the machine has the correct time
-ENV TZ=America/New_York
-
 RUN apt-get update \
     && apt-get install -y \
         curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM public.ecr.aws/docker/library/python:3.11-slim-bookworm as base
 
+# Set the timezone so the machine has the correct time
+ENV TZ=America/New_York
+
 RUN apt-get update \
     && apt-get install -y \
         curl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       AZURE_OPENAI_API_KEY: <API_KEY>
       AZURE_OPENAI_ENDPOINT: <ENDPOINT>
       AZURE_OPENAI_MODEL_DEPLOYMENT: gpt-4
+      TZ: America/New_York
     volumes:
       - '$HOME/.aws:/root/.aws'
       - '.:/workspace'


### PR DESCRIPTION
I found two issues when setting up the Docker `devcontainer` environment:

- `gcc` was required for the `poetry install` command but was not found
- The container is running at UTC timezone, so dates inside the container can be unexpected

Solution for `gcc` was to just run the `apt-get install` commands ahead of the `poetry install` and include gcc in the install list.

Solution for timezone that I chose was just to set "TZ: America/New_York" in docker-compose. Ideally it would get it from the host environment, but I didn't know of a platform-agnostic way to get that.